### PR TITLE
fix: add command groups

### DIFF
--- a/enchanted-shared/src/main/java/net/jailgens/enchanted/SharedCommandFactory.java
+++ b/enchanted-shared/src/main/java/net/jailgens/enchanted/SharedCommandFactory.java
@@ -44,6 +44,7 @@ public final class SharedCommandFactory implements CommandFactory {
         return new ClassCommand(command,
                 type,
                 new AnnotationCommandInfo(type.getAnnotations()),
-                converterRegistry);
+                converterRegistry,
+                this);
     }
 }


### PR DESCRIPTION
Command groups were documented in the API, but not implemented yet because of limitations with Mirror.

This was fixed in https://github.com/JailGens/mirror/pull/41.
